### PR TITLE
Clarify architecture decisions in docs

### DIFF
--- a/introduction.md
+++ b/introduction.md
@@ -364,6 +364,9 @@ WebFiori follows a modular architecture:
 
 * **Component Independence**: 14 independent packages — use only what you need
 * **Interface-Driven**: Storage backends (sessions, cache, queue, auth) are pluggable
+* **Facades**: Classes like `ContainerFacade` and `EventDispatcherFacade` are static proxies to underlying instances, following the convention popularized by the PHP community. For dependency injection or multiple instances, use the underlying classes directly.
+* **Request/Response**: `App::getRequest()` and `App::getResponse()` are per-request singletons. PHP's share-nothing execution model means each request runs in an isolated process — no shared state between users. These are safe to use as static accessors within a single request lifecycle.
+* **No separate controller layer required**: `WebService` classes can act as controllers directly — routing, validation, and request handling in one annotated class, similar to JAX-RS (Java) or ASP.NET minimal APIs. For full MVC, use `WebService` as a thin controller that delegates to service/repository classes. See [MVC Architecture](learn/mvc) for details.
 * **Request Lifecycle**: Request → Middleware (before) → Route Dispatch → Middleware (after) → Response → Middleware (afterSend)
 * **Extensibility**: Easy integration with third-party libraries
 * **Testing Support**: Full support for unit and integration testing with `CLITestCase` and `ServiceTestCase`

--- a/mvc.md
+++ b/mvc.md
@@ -27,6 +27,8 @@ WebFiori Framework supports the Model-View-Controller (MVC) architectural patter
 - **Repositories**: Data access layer using `AbstractRepository` for database operations
 - **API Controllers (Controller)**: Web services that handle HTTP requests using `WebService` class
 
+For JSON APIs, the response array serves as the view — the framework handles serialization. For server-rendered pages, WebFiori's [Theme system](learn/themes) and [WebPage classes](learn/web-pages) provide the view layer.
+
 This separation of concerns makes your code more maintainable, testable, and scalable.
 
 ## Architecture Overview


### PR DESCRIPTION
- Explain facades as static proxies (PHP community convention)
- Explain per-request singletons (safe in PHP's share-nothing model)
- Clarify WebService as controller with optional MVC layering
- Add view layer note to mvc.md (JSON response = view for APIs, themes for pages)